### PR TITLE
Update Test-ModsPath.ps1

### DIFF
--- a/Sources/WAU/Winget-AutoUpdate/functions/Test-ModsPath.ps1
+++ b/Sources/WAU/Winget-AutoUpdate/functions/Test-ModsPath.ps1
@@ -12,8 +12,9 @@ function Test-ModsPath ($ModsPath, $WingetUpdatePath, $AzureBlobSASURL) {
 
     # If path is URL
     if ($ExternalMods -like "http*") {
-        # enable TLS 1.2 and TLS 1.1 protocols
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12, [Net.SecurityProtocolType]::Tls11
+        # ADD TLS 1.2 and TLS 1.1 to list of currently used protocols
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls11
         #Get Index of $ExternalMods (or index page with href listing of all the Mods)
         try {
             $WebResponse = Invoke-WebRequest -Uri $ExternalMods -UseBasicParsing


### PR DESCRIPTION
Following the results of megaliner scan of main repo, we need to remove the hardcode of security protocols

# Proposed Changes
Replacing hardcoded definition of SecurityProtocol:
Was: SecurityProtocol = X,Y,Z 
Should be: SecurityProtocol += X, SecurityProtocol += Y, SecurityProtocol += Z 

## Related Issues
> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
